### PR TITLE
Support terrace building type

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2254,6 +2254,7 @@
 	<category name="buildings" order="70">
 		<type tag="building" value="residential" minzoom="15"/>
 		<entity_convert pattern="tag_transform" from_tag="building" from_value="apartments" to_tag1="building" to_value1="residential"/>
+		<entity_convert pattern="tag_transform" from_tag="building" from_value="terrace" to_tag1="building" to_value1="residential"/>
 		<entity_convert pattern="tag_transform" from_tag="building" from_value="dormitory" to_tag1="building" to_value1="residential"/>
 		<type tag="building" value="house" minzoom="15"/>
 		<entity_convert pattern="tag_transform" from_tag="building" from_value="houseboat" to_tag1="building" to_value1="house"/>


### PR DESCRIPTION
Add support for `building=terrace`. According to the wiki, it is "a single way used to define the outline of a linear row of residential dwellings, each of which normally has its own entrance, which form a terrace (row-house in North American English). Consider defining each dwelling separately using 'house'."

I don't really care if it should be represented as 'residential' as I propose, as 'house' (since it's a bunch of houses) or supported directly in the style, but I'd like to see the building type when I choose to color buildings by type in OsmAnd :). I could make the change if you prefer something else.